### PR TITLE
T1471: Fix wireguard entry in firewall template generator.

### DIFF
--- a/gen-interface-templates.pl
+++ b/gen-interface-templates.pl
@@ -93,7 +93,7 @@ my %firewall_hash = (
     'wireless/node.tag'                                      => 'wireless $VAR(../@)',
     'wireless/node.tag/vif/node.tag'                         => 'wireless $VAR(../../../@) vif $VAR(../@)',
     'wirelessmodem/node.tag'                                 => 'wirelessmodem $VAR(../@)',
-    'wireguard/node.tag'                                     => 'wireless $VAR(../@)',
+    'wireguard/node.tag'                                     => 'wireguard $VAR(../@)',
 );
 
 # Hash table to check if the priority needs to set @ root


### PR DESCRIPTION
This pull request fixes a typo in the firewall template generator that caused the firewall subtree to be omitted from the wireguard interface configuration.