### PR TITLE
cfg-firewall: T2868: Delete option pmtu for tcp-mss

### DIFF
--- a/templates/policy/route/node.tag/rule/node.tag/set/tcp-mss/node.def
+++ b/templates/policy/route/node.tag/rule/node.tag/set/tcp-mss/node.def
@@ -3,19 +3,12 @@ help: TCP Maximum Segment Size
 
 syntax:expression:
 exec "
-if [[ $VAR(@) =~ ^[[:alpha:]]*$ ]]; then                        \
-        if [ $VAR(@) == \"pmtu\" ]; then                        \
-                exit 0;                                         \
-        fi;                                                     \
-else                                                            \
-        if [[   ( $VAR(@) =~ ^[[:digit:]]*$ ) &&                \
-                ( $VAR(@) -ge \"500\" ) &&                      \
-                ( $VAR(@) -le \"1460\" ) ]]; then               \
-                exit 0;                                         \
-        fi;                                                     \
-fi;                                                             \
-echo Value must be \\'pmtu\\' or a number between 500 and 1460; \
+if [[   ( $VAR(@) =~ ^[[:digit:]]*$ ) &&          \
+        ( $VAR(@) -ge \"500\" ) &&                \
+        ( $VAR(@) -le \"1460\" ) ]]; then         \
+        exit 0;                                   \
+fi;                                               \
+echo Value must be a number between 500 and 1460; \
 exit 1"
 
-val_help: pmtu; Automatically set to Path Maximum Transfer Unit minus 40 bytes
 val_help: 500-1460; Explicitly set TCP MSS value


### PR DESCRIPTION
Delete wrong option tcp-mss pmtu for table mangle/prerouting
For "prerouting" VYATTA_FW_IN_HOOK we can't use the option **-j TCPMSS --clamp-mss-to-pmtu**, 
we can only handle **-j TCPMSS --set-mss xxxx**

```
root@r5:/home/vyos# sudo iptables -t mangle -A PREROUTING  -i eth0 -p tcp -m tcp --tcp-flags SYN SYN -j TCPMSS --clamp-mss-to-pmtu
iptables v1.8.2 (nf_tables):  RULE_APPEND failed (Invalid argument): rule in chain PREROUTING

vyos@r5# sudo dmesg | tail -n 1
[48323.007403] xt_TCPMSS: path-MTU clamping only supported in FORWARD, OUTPUT and POSTROUTING hooks
```