### PR TITLE
T3456: firewall: policy: rules that should be deleted seem to be still in use

### DIFF
--- a/gen-interface-policy-templates.pl
+++ b/gen-interface-policy-templates.pl
@@ -140,6 +140,7 @@ sub gen_template {
 
     print $tp <<EOF;
 type: txt
+priority: 615
 help: $table_help_hash{$table} ruleset for interface
 allowed: local -a params
 	eval "params=(\$(cli-shell-api listNodes policy $table))"

--- a/gen-interface-templates.pl
+++ b/gen-interface-templates.pl
@@ -136,6 +136,7 @@ sub gen_firewall_template {
         print $tp "priority: $interface_prio{ $if_tree }\n";
     }
     print $tp "help: Firewall options\n";
+    print $tp "priority: 615\n";
     die "ERROR: No firewall hash for ${if_tree}" unless $firewall_hash{"${if_tree}"};
     print $tp 'end: ${vyatta_sbindir}/vyatta-firewall-trap.pl --level="interfaces ';
     print $tp $firewall_hash{"${if_tree}"} . ' firewall"' . "\n";


### PR DESCRIPTION
Both `policy` and `firewall` did not contain proper priority nodes. Without those nodes it was not possible to delete the settings in only one commit.

This should be backported to 1.3 and 1.2 branches, too.