### PR TITLE
firewall: ICMP code/type: T3569

### DIFF
--- a/templates/firewall/name/node.tag/rule/node.tag/icmp/code/node.def
+++ b/templates/firewall/name/node.tag/rule/node.tag/icmp/code/node.def
@@ -3,3 +3,5 @@ type: u32; "ICMP code must be between 0 and 255"
 help: ICMP code (0-255)
 
 syntax:expression: $VAR(@) >=0 && $VAR(@) <= 255; "ICMP code must be between 0 and 255"
+
+val_help: u32:0-255; ICMP code

--- a/templates/firewall/name/node.tag/rule/node.tag/icmp/type/node.def
+++ b/templates/firewall/name/node.tag/rule/node.tag/icmp/type/node.def
@@ -3,3 +3,5 @@ type: u32; "ICMP type must be between 0 and 255"
 help: ICMP type (0-255)
 
 syntax:expression: $VAR(@) >=0 && $VAR(@) <= 255; "ICMP type must be between 0 and 255"
+
+val_help: u32:0-255; ICMP type


### PR DESCRIPTION
Fixed the completion help for icmp code & type which was showing out of range
values 0-4294967295 than the allowed values i.e. 0-255