### PR TITLE
firewall: T4100: default action number

### DIFF
--- a/lib/Vyatta/IpTables/Rule.pm
+++ b/lib/Vyatta/IpTables/Rule.pm
@@ -68,7 +68,7 @@ my %fields = (
 );
 
 my %dummy_rule = (
-    _rule_number => 10000,
+    _rule_number => 1000000,
     _protocol    => "all",
     _state       => {
         _established => undef,

--- a/scripts/firewall/vyatta-firewall.pl
+++ b/scripts/firewall/vyatta-firewall.pl
@@ -28,7 +28,7 @@ my $FW_LOCAL_HOOK = 'VYATTA_FW_LOCAL_HOOK';
 
 # FW_LOCALOUT_HOOK is only used in mangle table for PBR of locally initiated traffic
 my $FW_LOCALOUT_HOOK = 'VYATTA_FW_LOCALOUT_HOOK';
-my $max_rule = 10000;
+my $max_rule = 1000000;
 
 my (@setup, @updateints, @updaterules);
 my ($teardown, $teardown_ok);


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Firewall default rule changed from 10000 to 1000000.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4100

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes

Previously this rule was created by default:
```
RETURN     all  --  anywhere             anywhere             /* FOO-10000 default-action accept */
```
Now it creates this one:
```
RETURN     all  --  anywhere             anywhere             /* FOO-1000000 default-action accept */
```
## How to test

Create firewall rules

'''
set firewall name FOO default-action 'accept'
set firewall name FOO rule 10 action 'accept'
set firewall name FOO rule 10 source address '10.2.0.0/24'
set firewall name FOO rule 900000 action 'drop'
set firewall name FOO rule 900000 source address '10.0.0.0/24'
commit
'''

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly