### PR TITLE
interfaces: T4193: Ability to set firewall bridge to interface brX

### DIFF
--- a/templates/interfaces/bridge/node.tag/firewall/bridge/forward/ipv6-name/node.def
+++ b/templates/interfaces/bridge/node.tag/firewall/bridge/forward/ipv6-name/node.def
@@ -1,0 +1,5 @@
+type: txt
+help: Inbound IPv6 firewall ruleset name for interface
+allowed: local -a params
+	eval "params=($(cli-shell-api listNodes firewall ipv6-name))"
+	echo -n "${params[@]}"

--- a/templates/interfaces/bridge/node.tag/firewall/bridge/forward/name/node.def
+++ b/templates/interfaces/bridge/node.tag/firewall/bridge/forward/name/node.def
@@ -1,0 +1,5 @@
+type: txt
+help: Inbound IPv4 firewall ruleset name for interface
+allowed: local -a params
+	eval "params=($(cli-shell-api listNodes firewall name))"
+	echo -n "${params[@]}"

--- a/templates/interfaces/bridge/node.tag/firewall/bridge/forward/node.def
+++ b/templates/interfaces/bridge/node.tag/firewall/bridge/forward/node.def
@@ -1,0 +1,1 @@
+help: Ruleset for forwarded packets on inbound interface

--- a/templates/interfaces/bridge/node.tag/firewall/bridge/node.def
+++ b/templates/interfaces/bridge/node.tag/firewall/bridge/node.def
@@ -1,0 +1,3 @@
+help: Firewall bridge options
+priority: 616
+end: ${vyos_conf_scripts_dir}/firewall-interface-bridge.py $VAR(../../@)


### PR DESCRIPTION
Add new nodes "bridge forward" for attaching to the firewall bridge interface
For transparent firewall
https://phabricator.vyos.net/T4193

```
set interfaces bridge br0 firewall bridge forward name FOO
```
This PR requires file `firewall-interface-bridge.py` which will be included in vyos-1x