### PR TITLE
ipset: T4002: Generate a temporary set name from UUID

### DIFF
--- a/scripts/firewall/vyatta-ipset.pl
+++ b/scripts/firewall/vyatta-ipset.pl
@@ -288,7 +288,7 @@ sub update_set {
   # added or potentially changed => iterate members
   # to ensure that vyatta config and ipset stay in-sync, do the following:
   # 1. copy orig set to tmp set
-  my $tmpset = "$set_name-$$";
+  my $tmpset = substr `uuidgen 2>/dev/null`, 0, 31;
   if (($rc = ipset_copy_set($set_name, $set_type, $tmpset))) {
     # copy failed
     if ($newset) {


### PR DESCRIPTION
ipset allows assigning set names up to 31 characters long.

Currently, we use a process -PID number as a suffix for generating temporary set names. But this cuts effective set name to 25 characters only (`set name in CLI` + `-` + `PID number`), however in CLI we have a limit set to 31. So, set names with long prefixes cannot be configured.
This commit replaces PID-based temporary name with UUID-based, which allows configuring set names with full name size.