### PR TITLE
ipset: T2189: optimized firewall groups performance

### DIFF
--- a/templates/firewall/group/address-group/node.def
+++ b/templates/firewall/group/address-group/node.def
@@ -19,6 +19,10 @@ syntax:expression: exec "/opt/vyatta/sbin/vyatta-ipset.pl --action=is-group-defi
         --set-type=address --set-family=inet"; \
       "Firewall group name already used as Ipv6 group address"       
 
+commit:expression:exec "/opt/vyatta/sbin/vyatta-ipset.pl --action=check-duplicates --set-name=$VAR(@) \
+        --set-type=address --set-family=inet"; \
+       "There are duplicates inside address-group $VAR(@)"
+
 end: if sudo /opt/vyatta/sbin/vyatta-ipset.pl --action=update-set \
         --set-name="$VAR(@)" --set-type=address --set-family=inet; then
        ${vyatta_sbindir}/vyatta-firewall-trap.pl --level="firewall group address-group $VAR(@)"


### PR DESCRIPTION
This commit optimizes the speed of interaction with the ipset.

* removed extra `sudo` from `ipset` commands, because scripts that run `ipset` commands already run under `sudo`. This gives approximately 4x performance improvement.
* replaced logic in the `member_exists` function for port groups. Instead of calling `ipset -T` for each port now the whole list is received in one command and a search process is done inside Perl. This significantly improves speed for port groups with long port ranges inside.
* delete ip address and port ranges using a single command instead deleting each element individually.