### PR TITLE
T6215: Replace confusing error messages with clear ones

### DIFF
--- a/scripts/firewall/vyatta-firewall.pl
+++ b/scripts/firewall/vyatta-firewall.pl
@@ -565,7 +565,7 @@ sub update_rules {
 
     if ($all_rules_deleted and Vyatta::IpTables::Mgr::chain_referenced($table, $name, $iptables_cmd)) {
         # Disallow deleting a chain if it's still referenced
-        Vyatta::Config::outputError([$tree,$name],"Firewall configuration error: Cannot delete rule set \"$name\" (still in use)\n");
+        Vyatta::Config::outputError([$tree,$name],"Firewall configuration error: The firewall rule set \"$name\" cannot be empty while it is still in use\n");
         exit 1;
     }
 


### PR DESCRIPTION
**Replace confusing error messages with clear ones:**
The configuration:
```
set firewall name fw_test default-action 'accept'
set firewall name fw_test rule 100 action 'accept'
set interfaces ethernet eth1 firewall in name 'fw_test'
```

When we try to delete the rule 100
```
delete firewall name fw_test rule 100
commit
```

The error message confuses the customer (not clear to the customer)
```
[ firewall name fw_test ]
Firewall configuration error: Cannot delete rule set "fw_test" (still in use)

[[firewall name fw_test]] failed
Commit failed
[edit]
```
```
[edit firewall name fw_test]
-rule 100 {
-    action accept
-}
```